### PR TITLE
Add support for sklearn up to 1.3.x

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -37,4 +37,4 @@ jobs:
         run: pip install .
 
       - name: Run tests (pytest)
-        run: pytest --disable-warnings -vv -rxXs python/test
+        run: pytest --disable-warnings -vv -ra python/test

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   push:
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   tests:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -8,8 +8,8 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
-        pyspark-version: ["3.3.2", "3.4.0"]
+        python-version: ["3.11"]
+        pyspark-version: ["3.5.1"]
         java-version: ["8", "11"]
         exclude:
           - python-version: "3.11"

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -11,13 +11,6 @@ jobs:
         python-version: ["3.11"]
         pyspark-version: ["3.5.1"]
         java-version: ["8", "11"]
-        exclude:
-          - python-version: "3.11"
-            pyspark-version: "3.3.2"
-            java-version: "8"
-          - python-version: "3.11"
-            pyspark-version: "3.3.2"
-            java-version: "11"
 
     steps:
       - name: Checkout code

--- a/python/skspark/sklearn_1/_search.py
+++ b/python/skspark/sklearn_1/_search.py
@@ -26,13 +26,7 @@ from sklearn.model_selection._split import check_cv
 from sklearn.model_selection._validation import _fit_and_score, _insert_error_scores, _warn_or_raise_about_fit_failures
 from sklearn.utils._param_validation import HasMethods, Interval, StrOptions
 from sklearn.utils.parallel import Parallel, delayed
-from sklearn.utils.validation import indexable
-
-try:
-    from sklearn.utils.validation import _check_fit_params
-except ImportError:
-    # sklearn >=1.4
-    from sklearn.utils.validation import _check_method_params as _check_fit_params
+from sklearn.utils.validation import _check_fit_params, indexable
 
 __all__ = ["GridSearchCV", "RandomizedSearchCV"]
 

--- a/python/skspark/sklearn_1/_search.py
+++ b/python/skspark/sklearn_1/_search.py
@@ -26,7 +26,13 @@ from sklearn.model_selection._split import check_cv
 from sklearn.model_selection._validation import _fit_and_score, _insert_error_scores, _warn_or_raise_about_fit_failures
 from sklearn.utils._param_validation import HasMethods, Interval, StrOptions
 from sklearn.utils.parallel import Parallel, delayed
-from sklearn.utils.validation import _check_fit_params, indexable
+from sklearn.utils.validation import indexable
+
+try:
+    from sklearn.utils.validation import _check_fit_params
+except ImportError:
+    # sklearn >=1.4
+    from sklearn.utils.validation import _check_method_params as _check_fit_params
 
 __all__ = ["GridSearchCV", "RandomizedSearchCV"]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pandoc>=1.0.2
-scikit-learn==1.7.2
+scikit-learn==1.3.2
 six==1.11.0
 numpy>=1.13.0
 scipy>=0.19.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pandoc>=1.0.2
-scikit-learn==1.2.2
+scikit-learn==1.7.2
 six==1.11.0
 numpy>=1.13.0
 scipy>=0.19.0
-pyspark==3.3.2
+pyspark==3.5.1

--- a/setup.py
+++ b/setup.py
@@ -9,11 +9,11 @@ keywords = [
     "sklearn",
     "machine learning",
     "random search",
-    "grid search"
+    "grid search",
 ]
 
 install_requires = [
-    "scikit-learn~=1.0",
+    "scikit-learn>1.0,<1.4",
 ]
 
 with open("README.md", "r") as fh:
@@ -26,7 +26,7 @@ setup(
     author_email="g.n.sivalingam@gmail.com",
     description=description,
     long_description=long_description,
-    long_description_content_type='text/markdown',
+    long_description_content_type="text/markdown",
     keywords=keywords,
     package_dir={"": "python"},
     packages=find_packages("python", exclude="tests"),
@@ -35,7 +35,7 @@ setup(
     extras_require={
         "spark": ["pyspark[sql]~=3.0"],
     },
-    license="Apache 2.0"
+    license="Apache 2.0",
 )
 
 # TODO add classifiers


### PR DESCRIPTION
_Work in progress_

Had started to look into updating to support newer sklearn releases, but seems 1.3.x is as new as we can go as a bunch of `_search.py` was changed in sklearn 1.4.x