### PR TITLE
ci: add publish target selector to release dispatch

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -4,6 +4,14 @@ on:
   push:
   pull_request:
   workflow_dispatch:
+    inputs:
+      target:
+        description: "Publish target for this manual run"
+        type: choice
+        default: testpypi
+        options:
+          - testpypi
+          - pypi
 
 jobs:
   tests:
@@ -59,7 +67,9 @@ jobs:
   # collide.
   publish-testpypi:
     needs: tests
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    if: >-
+      (github.event_name == 'push' && github.ref == 'refs/heads/master') ||
+      (github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi')
     runs-on: ubuntu-24.04
     environment: testpypi
     permissions:
@@ -100,7 +110,9 @@ jobs:
   # PyPI publish.
   publish-pypi:
     needs: tests
-    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/master'
+    if: >-
+      github.event_name == 'workflow_dispatch' && inputs.target == 'pypi' &&
+      github.ref == 'refs/heads/master'
     runs-on: ubuntu-24.04
     environment: pypi
     permissions:

--- a/developer-notes.md
+++ b/developer-notes.md
@@ -37,7 +37,9 @@ Releases go out of CI via PyPI Trusted Publishing (OIDC) — no tokens are store
    section to `changelog.md` describing the work.
 2. Merge to `master`. The CI pipeline runs the test matrix, then publishes
    `x.y.z.dev<run_number>` to **TestPyPI** as a packaging smoke test (unique per push).
-3. Go to **Actions → CI → Run workflow** (on `master`). The `publish-pypi` job:
+3. Go to **Actions → CI → Run workflow** (on `master`) and set **target = `pypi`**
+   (the default is `testpypi`, which lets you re-trigger a dev publish on demand
+   for debugging without pushing a dummy commit). The `publish-pypi` job:
    - re-runs the full test matrix,
    - validates `vx.y.z` is not already a git tag and `x.y.z` is not already on PyPI,
    - builds, then creates and pushes the annotated tag `vx.y.z`,


### PR DESCRIPTION
## Why

The release pipeline (added in #22) only published to PyPI via `workflow_dispatch` and to TestPyPI via push-to-master. When the first TestPyPI publish failed with `invalid-publisher`, there was no way to re-run *just* the TestPyPI publish on demand — you'd have to push a throwaway commit to master to retrigger it. This adds a manual lever to pick the publish target, which is useful both for debugging the trusted-publisher setup and for keeping prod releases an explicit, deliberate choice.

## What changed

- Added a **`target`** choice input to the `workflow_dispatch` trigger: `testpypi` | `pypi`, **default `testpypi`**.
- `publish-testpypi` now also runs on `workflow_dispatch` when `target == testpypi` (in addition to every push to master) — so a dev build can be re-triggered on demand.
- `publish-pypi` now requires `target == pypi` (still `master`-only) — a production release is never the default; it must be selected explicitly.
- `developer-notes.md`: documented selecting `target = pypi` when cutting a release, and that the default `testpypi` enables on-demand dev re-publishes.

Resulting dispatch behaviour:

| Trigger | Result |
|---|---|
| push to `master` | TestPyPI dev publish |
| dispatch, `target=testpypi` (default) | TestPyPI dev publish (on-demand) |
| dispatch, `target=pypi` | full prod release (gated by the `pypi` environment's required reviewer) |

## Note

`workflow_dispatch` inputs only surface in the Actions UI once the workflow is on the default branch, so this dispatch lever becomes available after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
